### PR TITLE
change status heartbeat bar as 5 min in 1 beat

### DIFF
--- a/src/components/HeartbeatPerPeriodBar.vue
+++ b/src/components/HeartbeatPerPeriodBar.vue
@@ -1,0 +1,232 @@
+<template>
+    <div ref="wrap" class="wrap" :style="wrapStyle">
+        <div class="hp-bar-big" :style="barStyle">
+            <div
+                v-for="(beat, index) in shortBeatList"
+                :key="index"
+                class="beat"
+                :class="{ 'empty' : (beat === 0), 'down' : (beat.status === 0), 'pending' : (beat.status === 2), 'maintenance' : (beat.status === 3) }"
+                :style="beatStyle"
+                :title="getBeatTitle(beat)"
+            />
+        </div>
+    </div>
+</template>
+
+<script>
+
+export default {
+    props: {
+        /** Size of the heartbeat bar */
+        size: {
+            type: String,
+            default: "big",
+        },
+        /** ID of the monitor */
+        monitorId: {
+            type: Number,
+            required: true,
+        },
+        /** Array of the monitors heartbeats */
+        heartbeatList: {
+            type: Array,
+            default: null,
+        },
+    },
+    data() {
+        return {
+            beatWidth: 10,
+            beatHeight: 30,
+            hoverScale: 1.5,
+            beatMargin: 4,
+            move: false,
+            maxBeat: -1,
+        };
+    },
+    computed: {
+
+        /**
+         * If heartbeatList is null, get it from $root.heartbeatList
+         */
+        beatList() {
+            if (this.heartbeatList === null) {
+                return this.$root.heartbeatPeriodList[this.monitorId];
+            } else {
+                return this.heartbeatList;
+            }
+        },
+
+        shortBeatList() {
+            if (! this.beatList) {
+                return [];
+            }
+
+            let placeholders = [];
+
+            let start = this.beatList.length - this.maxBeat;
+
+            if (this.move) {
+                start = start - 1;
+            }
+
+            if (start < 0) {
+                // Add empty placeholder
+                for (let i = start; i < 0; i++) {
+                    placeholders.push(0);
+                }
+                start = 0;
+            }
+
+            return placeholders.concat(this.beatList.slice(start));
+        },
+
+        wrapStyle() {
+            let topBottom = (((this.beatHeight * this.hoverScale) - this.beatHeight) / 2);
+            let leftRight = (((this.beatWidth * this.hoverScale) - this.beatWidth) / 2);
+
+            return {
+                padding: `${topBottom}px ${leftRight}px`,
+                width: "100%",
+            };
+        },
+
+        barStyle() {
+            if (this.move && this.shortBeatList.length > this.maxBeat) {
+                let width = -(this.beatWidth + this.beatMargin * 2);
+
+                return {
+                    transition: "all ease-in-out 0.25s",
+                    transform: `translateX(${width}px)`,
+                };
+
+            }
+            return {
+                transform: "translateX(0)",
+            };
+
+        },
+
+        beatStyle() {
+            return {
+                width: this.beatWidth + "px",
+                height: this.beatHeight + "px",
+                margin: this.beatMargin + "px",
+                "--hover-scale": this.hoverScale,
+            };
+        },
+
+    },
+    watch: {
+        beatList: {
+            handler(val, oldVal) {
+                this.move = true;
+
+                setTimeout(() => {
+                    this.move = false;
+                }, 300);
+            },
+            deep: true,
+        },
+    },
+    unmounted() {
+        window.removeEventListener("resize", this.resize);
+    },
+    beforeMount() {
+        if (this.heartbeatList === null) {
+            if (! (this.monitorId in this.$root.heartbeatPeriodList)) {
+                this.$root.heartbeatPeriodList[this.monitorId] = [];
+            }
+        }
+    },
+
+    mounted() {
+        if (this.size === "small") {
+            this.beatWidth = 5;
+            this.beatHeight = 16;
+            this.beatMargin = 2;
+        }
+
+        // Suddenly, have an idea how to handle it universally.
+        // If the pixel * ratio != Integer, then it causes render issue, round it to solve it!!
+        const actualWidth = this.beatWidth * window.devicePixelRatio;
+        const actualMargin = this.beatMargin * window.devicePixelRatio;
+
+        if (! Number.isInteger(actualWidth)) {
+            this.beatWidth = Math.round(actualWidth) / window.devicePixelRatio;
+        }
+
+        if (! Number.isInteger(actualMargin)) {
+            this.beatMargin = Math.round(actualMargin) / window.devicePixelRatio;
+        }
+
+        window.addEventListener("resize", this.resize);
+        this.resize();
+    },
+    methods: {
+        /** Resize the heartbeat bar */
+        resize() {
+            if (this.$refs.wrap) {
+                this.maxBeat = Math.floor(this.$refs.wrap.clientWidth / (this.beatWidth + this.beatMargin * 2));
+            }
+        },
+
+        /**
+         * Get the title of the beat.
+         * Used as the hover tooltip on the heartbeat bar.
+         * @param {Object} beat Beat to get title from
+         * @returns {string}
+         */
+        getBeatTitle(beat) {
+            return `${this.$root.datetime(beat.time)}` + ((beat.msg) ? ` - ${beat.msg}` : "");
+        },
+
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../assets/vars.scss";
+
+.wrap {
+    overflow: hidden;
+    width: 100%;
+    white-space: nowrap;
+}
+
+.hp-bar-big {
+    .beat {
+        display: inline-block;
+        background-color: $primary;
+        border-radius: $border-radius;
+
+        &.empty {
+            background-color: aliceblue;
+        }
+
+        &.down {
+            background-color: $danger;
+        }
+
+        &.pending {
+            background-color: $warning;
+        }
+
+        &.maintenance {
+            background-color: $maintenance;
+        }
+
+        &:not(.empty):hover {
+            transition: all ease-in-out 0.15s;
+            opacity: 0.8;
+            transform: scale(var(--hover-scale));
+        }
+    }
+}
+
+.dark {
+    .hp-bar-big .beat.empty {
+        background-color: #848484;
+    }
+}
+
+</style>

--- a/src/components/PublicGroupList.vue
+++ b/src/components/PublicGroupList.vue
@@ -33,7 +33,7 @@
                         <template #item="monitor">
                             <div class="item">
                                 <div class="row">
-                                    <div class="col-9 col-md-8 small-padding">
+                                    <div class="col-md-3 small-padding">
                                         <div class="info">
                                             <font-awesome-icon v-if="editMode" icon="arrows-alt-v" class="action drag me-3" />
                                             <font-awesome-icon v-if="editMode" icon="times" class="action remove me-3" @click="removeMonitor(group.index, monitor.index)" />
@@ -65,8 +65,9 @@
                                             <Tag v-for="tag in monitor.element.tags" :key="tag" :item="tag" :size="'sm'" />
                                         </div>
                                     </div>
-                                    <div :key="$root.userHeartbeatBar" class="col-3 col-md-4">
-                                        <HeartbeatBar size="small" :monitor-id="monitor.element.id" />
+                                    <div :key="$root.userHeartbeatBar" class="col-md-9">
+                                        <!-- <HeartbeatBar size="small" :monitor-id="monitor.element.id" /> -->
+                                        <HeartbeatPerPeriodBar size="small" :monitor-id="monitor.element.id" />
                                     </div>
                                 </div>
                             </div>
@@ -82,7 +83,8 @@
 <script>
 import MonitorSettingDialog from "./MonitorSettingDialog.vue";
 import Draggable from "vuedraggable";
-import HeartbeatBar from "./HeartbeatBar.vue";
+// import HeartbeatBar from "./HeartbeatBar.vue";
+import HeartbeatPerPeriodBar from "./HeartbeatPerPeriodBar.vue";
 import Uptime from "./Uptime.vue";
 import Tag from "./Tag.vue";
 
@@ -90,7 +92,8 @@ export default {
     components: {
         MonitorSettingDialog,
         Draggable,
-        HeartbeatBar,
+        // HeartbeatBar,
+        HeartbeatPerPeriodBar,
         Uptime,
         Tag,
     },

--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -39,6 +39,7 @@ export default {
             maintenanceList: {},
             apiKeyList: {},
             heartbeatList: { },
+            heartbeatPeriodList: { },
             importantHeartbeatList: { },
             avgPingList: { },
             uptimeList: { },

--- a/src/pages/StatusPage.vue
+++ b/src/pages/StatusPage.vue
@@ -743,10 +743,11 @@ export default {
             // If editMode, it will use the data from websocket.
             if (! this.editMode) {
                 axios.get("/api/status-page/heartbeat/" + this.slug).then((res) => {
-                    const { heartbeatList, uptimeList } = res.data;
+                    const { heartbeatList, uptimeList, heartbeatPeriodList } = res.data;
 
                     this.$root.heartbeatList = heartbeatList;
                     this.$root.uptimeList = uptimeList;
+                    this.$root.heartbeatPeriodList = heartbeatPeriodList;
 
                     const heartbeatIds = Object.keys(heartbeatList);
                     const downMonitors = heartbeatIds.reduce((downMonitorsAmount, currentId) => {


### PR DESCRIPTION
- Expand status heartbeat bar length
- Change 1 beat as status in each 5 minutes
  - Shown priority is `Down` > `Maintenance` > `Pending` > `Up`


![スクリーンショット 2023-07-27 17 18 19](https://github.com/startialab-inc/uptime-kuma/assets/103615455/f5295231-aee0-4ce6-aa1f-8fec59111c0b)

Download this dist and update local one↓
[dist.tar.gz](https://github.com/startialab-inc/uptime-kuma/files/12181034/dist.tar.gz)


<!--
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/uptime-kuma/blob/master/CONTRIBUTING.md#can-i-create-a-pull-request-for-uptime-kuma

Tick the checkbox if you understand [x]: 
- [ ] I have read and understand the pull request rules.

# Description

Fixes #(issue)

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- User interface (UI)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Other
- This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ ] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
-->
